### PR TITLE
fix: search for user by email using user api

### DIFF
--- a/lib/findUsersByEmail.js
+++ b/lib/findUsersByEmail.js
@@ -2,8 +2,8 @@ const apiCall = require('./api');
 
 const findUsersByEmail = email =>
   apiCall({
-    path: 'users-by-email',
-    qs: { email }
+    path: 'users',
+    qs: { q: `email:"${email}"` }
   });
 
 module.exports = findUsersByEmail;

--- a/rules/link.js
+++ b/rules/link.js
@@ -23,7 +23,6 @@ module.exports = ({ extensionURL = '', username = 'Unknown', clientID = '', clie
     endpoints: {
       linking: '${extensionURL.replace(/\/$/g, '')}',
       userApi: auth0.baseUrl + '/users',
-      usersByEmailApi: auth0.baseUrl + '/users-by-email'
     },
     token: {
       clientId: '${clientID}',
@@ -201,9 +200,9 @@ module.exports = ({ extensionURL = '', username = 'Unknown', clientID = '', clie
 
   function searchUsersWithSameEmail() {
     return apiCall({
-      url: config.endpoints.usersByEmailApi,
+      url: config.endpoints.userApi,
       qs: {
-        email: user.email
+        q: 'email:"' + user.email + '"',
       }
     });
   }


### PR DESCRIPTION
Rather than using the users-by-email api to search for users by email (case sensitive)
switch to using the users API and search by email (case insensitive)

:warning: the users api is eventually consistent but I don't believe this will be a problem in our case

https://auth0.com/docs/manage-users/user-search
